### PR TITLE
fixes #6 - allow compatibility with NixOs proper

### DIFF
--- a/src/sbt-test/sbtix/simple/default.nix
+++ b/src/sbt-test/sbtix/simple/default.nix
@@ -10,7 +10,7 @@ in
 
         installPhase =
             ''
-                sbt three/stage -Dplugin.version=0.1-SNAPSHOT
+                sbt three/stage
                 cp -r three/target/universal/stage $out
             '';
     }


### PR DESCRIPTION
I have added SBT options under the SBT_OPTS environment variable so that they will affect any sbt command in sbtix.nix or default.nix.

```
SBT_OPTS = ''
             -Dsbt.ivy.home=./.ivy2/
             -Dsbt.boot.directory=./.sbt/boot/
             -Dsbt.override.build.repos=true
             -Dsbt.repository.config=./.sbtix_repos
             ${sbtOptions}'';
```

The sbt.ivy.home and sbt.boot.directory settings fix the problems from #6 with NixOs.

In addition I added options to override sbt repositories with a listing set by sbtix.nix.  I believe this will affect both plugin project and build project resolvers.  My listing includes everything I thought would be needed to perform most builds, but once the sbtix project is more mature it should be reduced to just the repo provided by sbtix.
