### PR TITLE
fixes #1 - identify pom,jar,ivy artifacts locally

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,8 +6,8 @@ let
     name = "sbtix-repo-0.1";
   
     src = fetchurl {
-      url = https://github.com/cessationoftime/Sbtix/releases/download/bootstrap/sbtix-ivyrepo-0.1.tar.gz;
-      sha256 = "16k9w94cq933ap1psq5kdvcl6n9rkzjxbw27pc212n89xxl8vnfl";
+      url = https://github.com/cessationoftime/Sbtix/releases/download/artifacts-bootstrap/sbtix-ivyrepo-0.1.tar.gz;
+      sha256 = "05f9bxllqdygs4q6s484k2jw5v2ikizwbif8p95j85dg9qz58dxk";
     };
 
     phases = [ "unpackPhase" "installPhase" ];

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ let
   
     src = fetchurl {
       url = https://github.com/cessationoftime/Sbtix/releases/download/artifacts-bootstrap/sbtix-ivyrepo-0.1.tar.gz;
-      sha256 = "05f9bxllqdygs4q6s484k2jw5v2ikizwbif8p95j85dg9qz58dxk";
+      sha256 = "1ncwli6b3di7hxmp67p5chn3f5z7yfljkfk1xxv3j8i52wa53acp";
     };
 
     phases = [ "unpackPhase" "installPhase" ];

--- a/plugin/project/plugins.sbt
+++ b/plugin/project/plugins.sbt
@@ -1,3 +1,3 @@
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M13")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M14")

--- a/plugin/src/sbt-test/sbtix/private-auth/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbtix/private-auth/project/plugins.sbt
@@ -6,3 +6,6 @@ if (sys.props.contains("plugin.version")) {
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.4")
 
+resolvers += Resolver.typesafeIvyRepo("releases")
+
+resolvers += Resolver.sbtPluginRepo("releases")

--- a/plugin/src/sbt-test/sbtix/simple/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbtix/simple/project/plugins.sbt
@@ -5,3 +5,7 @@ if (sys.props.contains("plugin.version")) {
 }
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.4")
+
+resolvers += Resolver.typesafeIvyRepo("releases")
+
+resolvers += Resolver.sbtPluginRepo("releases")


### PR DESCRIPTION
This change both fixes #1 and it eliminates some prerequisites to solving #2.

It downloads artifacts from the remote repository like it did previously, but now it uses the location of the downloaded jar to recursively search its parent directories and find the location of the downloaded jar, pom and ivy.xml artifacts. Once it identifies the downloaded artifact locations it uses those paths to build the remote urls for all artifacts.

This change has greater compatibility with Ivy repositories since it does not always look for a pom file and will identify ivy.xml files and place them in repo.nix.  Ivy compatibility is required to solve issue #2.
