### PR TITLE
Support libraries built by Sbtix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea
+*.iml
 target
 result
+tests/**/repo.nix
+.ensime_cache
+.ensime

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,8 @@ before_install:
   - nix-env -i nix-prefetch-scripts
 sudo: required
 script:
-  - cd plugin
+  - pushd plugin
   - sbt scripted
+  - popd
+  - nix-env -i -f .
+  - tests/multi-build/run.sh

--- a/README.md
+++ b/README.md
@@ -40,32 +40,26 @@ Sbtix provides a script which will connect your project to the sbtix global plug
 
 ### Creating a build
 
- * create default.nix. As shown below. Edit as necessary.
+ * create default.nix as shown below. Edit as necessary. This assumes that you're building a program using [sbt-native-packager](http://www.scala-sbt.org/sbt-native-packager/index.html), use `buildSbtLibrary` instead if you want to build a library or `buildSbtProject` if you want to use a free-form `installPhase`.
 
 ```nix
 { pkgs ? import <nixpkgs> {} }: with pkgs;
 let
     sbtixDir = fetchFromGitHub {
-    owner = "teozkr";
-    repo = "Sbtix";
-    rev = "<<current git rev>>"; # Replace as needed
-    sha256 = "1fy7y4ln63ynad5v9w4z8srb9c8j2lz67fjsf6a923czm9lh0000"; # Replace as needed
+        owner = "teozkr";
+        repo = "Sbtix";
+        rev = "<<current git rev>>"; # Replace as needed
+        sha256 = "1fy7y4ln63ynad5v9w4z8srb9c8j2lz67fjsf6a923czm9lh0000"; # Replace as needed
     };
     sbtix = pkgs.callPackage "${sbtixDir}/sbtix.nix" {};
 in
-    sbtix.buildSbtProject {
+    sbtix.buildSbtProgram {
         name = "sbtix-example";
         src = ./.;
         repo = [ (import ./manual-repo.nix)
                  (import ./repo.nix)
                  (import ./project/repo.nix)
                ];
-
-        installPhase =''
-          sbt publish-local
-          mkdir -p $out/
-          cp ./.ivy2/local/* $out/ -r
-        '';
     }
 ```
 

--- a/tests/multi-build/one/One.scala
+++ b/tests/multi-build/one/One.scala
@@ -1,0 +1,5 @@
+object One {
+  def doStuff() {
+    println("Hello from one")
+  }
+}

--- a/tests/multi-build/one/build.sbt
+++ b/tests/multi-build/one/build.sbt
@@ -1,0 +1,7 @@
+organization := "sbtix-test-multibuild"
+
+name := "mb-one"
+
+version := "0.1.0-SNAPSHOT"
+
+projectID := projectID.value.extra("nix" -> "")

--- a/tests/multi-build/one/manual-repo.nix
+++ b/tests/multi-build/one/manual-repo.nix
@@ -1,0 +1,42 @@
+# this file must still be generated manually.  
+{
+  "repos" = {
+    "nix-public" = "";
+    "nix-typesafe-ivy-releases" = "[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]";
+  };
+  "artifacts" = {
+    # dependencies so sbt can build the sbt-compiler-interface (http://www.scala-sbt.org/0.13/docs/Compiler-Interface.html)
+    "nix-public/org/scala-lang/jline/2.10.6/jline-2.10.6.pom" = {
+      url = "https://repo1.maven.org/maven2/org/scala-lang/jline/2.10.6/jline-2.10.6.pom";
+      sha256 = "16mg4b2c1m6gcq901wy6f6jpy8spw2yh909gi826xykq89ja94dg";
+    };
+    "nix-public/org/scala-lang/jline/2.10.6/jline-2.10.6.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scala-lang/jline/2.10.6/jline-2.10.6.jar";
+      sha256 = "1cfk6whncx2g87grwdfmz6f76bn807saqik91iwcfv099b1jngw1";
+    };
+    "nix-public/jline/jline/2.12.1/jline-2.12.1.pom" = {
+      url = "https://repo1.maven.org/maven2/jline/jline/2.12.1/jline-2.12.1.pom";
+      sha256 = "0pzjaccy3svy4arrzs02c2yif7plbwlr39kvs38qr68ij0v20m0j";
+    };
+    "nix-public/jline/jline/2.12.1/jline-2.12.1.jar" = {
+      url = "https://repo1.maven.org/maven2/jline/jline/2.12.1/jline-2.12.1.jar";
+      sha256 = "03wl5r6xd58n5504rspqx086kjaw55faxa5fz2kghipg5k7is7y3";
+    };
+    "nix-public/org/fusesource/jansi/jansi/1.4/jansi-1.4.pom" = {
+      url = "https://repo1.maven.org/maven2/org/fusesource/jansi/jansi/1.4/jansi-1.4.pom";
+      sha256 = "0rgprkbg4ljarf0x79snk2h1b0974glhl2fw1bxkxbw8k3ifda1s";
+    };
+    "nix-public/org/fusesource/jansi/jansi/1.4/jansi-1.4.jar" = {
+      url = "https://repo1.maven.org/maven2/org/fusesource/jansi/jansi/1.4/jansi-1.4.jar";
+      sha256 = "183ms545msn02fl0181rwbcifc8qy82rz4l6dglnhv9la8a1bnc2";
+    };
+    "nix-public/org/sonatype/oss/oss-parent/7/oss-parent-7.pom" = {
+      url = "https://repo1.maven.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom";
+      sha256 = "0m4lallnlhyfj3z24ispxzwvsxzaznhw6zsmk4j74sibr5kqh7xm";
+    };
+    "nix-typesafe-ivy-releases/org.scala-sbt/compiler-interface/0.13.12/srcs/compiler-interface-sources.jar" = {
+      url = "https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/compiler-interface/0.13.12/srcs/compiler-interface-sources.jar";
+      sha256 = "0rjjdc283wdv861yy9x0ssn5bh7mm371sznvp5hsayynd7h0r0z7";
+    };
+  };
+}

--- a/tests/multi-build/one/one.nix
+++ b/tests/multi-build/one/one.nix
@@ -1,0 +1,9 @@
+{sbtix}:
+sbtix.buildSbtLibrary {
+    name = "sbtix-multibuild-one";
+    src = ./.;
+    repo = [ (import ./manual-repo.nix)
+             (import ./repo.nix)
+             (import ./project/repo.nix)
+           ];
+}

--- a/tests/multi-build/one/project/build.properties
+++ b/tests/multi-build/one/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.12

--- a/tests/multi-build/run.sh
+++ b/tests/multi-build/run.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -euxo pipefail
+cd "$(dirname "$0")"
+
+for f in {one,two,three}/{,project/}repo.nix; do
+    if test -e $f; then
+        rm "$f"
+    fi
+done
+
+pushd one
+sbtix-gen-all
+popd
+
+pushd two
+sbtix-gen
+popd
+
+pushd three
+sbtix-gen-all
+nix-build
+./result/bin/mb-three

--- a/tests/multi-build/run.sh
+++ b/tests/multi-build/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -euxo pipefail
 cd "$(dirname "$0")"

--- a/tests/multi-build/run.sh
+++ b/tests/multi-build/run.sh
@@ -21,3 +21,4 @@ pushd three
 sbtix-gen-all
 nix-build
 ./result/bin/mb-three
+popd

--- a/tests/multi-build/three/Three.scala
+++ b/tests/multi-build/three/Three.scala
@@ -1,0 +1,11 @@
+object Three {
+  def doStuff() {
+    println("Hello from three")
+  }
+}
+
+object Main extends App {
+  One.doStuff()
+  Two.doStuff()
+  Three.doStuff()
+}

--- a/tests/multi-build/three/build.sbt
+++ b/tests/multi-build/three/build.sbt
@@ -1,0 +1,13 @@
+val org = "sbtix-test-multibuild"
+
+val ver = "0.1.0-SNAPSHOT"
+
+organization := org
+
+name := "mb-three"
+
+version := ver
+
+libraryDependencies += org %% "mb-two" % ver extra ("nix" -> "")
+
+enablePlugins(JavaAppPackaging)

--- a/tests/multi-build/three/default.nix
+++ b/tests/multi-build/three/default.nix
@@ -1,0 +1,12 @@
+{pkgs ? import <nixpkgs> {}, sbtix ? pkgs.callPackage ../../../sbtix.nix {}}:
+let
+    one = pkgs.callPackage ../one/one.nix {
+        inherit sbtix;
+    };
+    two = pkgs.callPackage ../two/two.nix {
+        inherit sbtix one;
+    };
+    three = pkgs.callPackage ./three.nix {
+        inherit sbtix two;
+    };
+in three

--- a/tests/multi-build/three/manual-repo.nix
+++ b/tests/multi-build/three/manual-repo.nix
@@ -1,0 +1,42 @@
+# this file must still be generated manually.  
+{
+  "repos" = {
+    "nix-public" = "";
+    "nix-typesafe-ivy-releases" = "[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]";
+  };
+  "artifacts" = {
+    # dependencies so sbt can build the sbt-compiler-interface (http://www.scala-sbt.org/0.13/docs/Compiler-Interface.html)
+    "nix-public/org/scala-lang/jline/2.10.6/jline-2.10.6.pom" = {
+      url = "https://repo1.maven.org/maven2/org/scala-lang/jline/2.10.6/jline-2.10.6.pom";
+      sha256 = "16mg4b2c1m6gcq901wy6f6jpy8spw2yh909gi826xykq89ja94dg";
+    };
+    "nix-public/org/scala-lang/jline/2.10.6/jline-2.10.6.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scala-lang/jline/2.10.6/jline-2.10.6.jar";
+      sha256 = "1cfk6whncx2g87grwdfmz6f76bn807saqik91iwcfv099b1jngw1";
+    };
+    "nix-public/jline/jline/2.12.1/jline-2.12.1.pom" = {
+      url = "https://repo1.maven.org/maven2/jline/jline/2.12.1/jline-2.12.1.pom";
+      sha256 = "0pzjaccy3svy4arrzs02c2yif7plbwlr39kvs38qr68ij0v20m0j";
+    };
+    "nix-public/jline/jline/2.12.1/jline-2.12.1.jar" = {
+      url = "https://repo1.maven.org/maven2/jline/jline/2.12.1/jline-2.12.1.jar";
+      sha256 = "03wl5r6xd58n5504rspqx086kjaw55faxa5fz2kghipg5k7is7y3";
+    };
+    "nix-public/org/fusesource/jansi/jansi/1.4/jansi-1.4.pom" = {
+      url = "https://repo1.maven.org/maven2/org/fusesource/jansi/jansi/1.4/jansi-1.4.pom";
+      sha256 = "0rgprkbg4ljarf0x79snk2h1b0974glhl2fw1bxkxbw8k3ifda1s";
+    };
+    "nix-public/org/fusesource/jansi/jansi/1.4/jansi-1.4.jar" = {
+      url = "https://repo1.maven.org/maven2/org/fusesource/jansi/jansi/1.4/jansi-1.4.jar";
+      sha256 = "183ms545msn02fl0181rwbcifc8qy82rz4l6dglnhv9la8a1bnc2";
+    };
+    "nix-public/org/sonatype/oss/oss-parent/7/oss-parent-7.pom" = {
+      url = "https://repo1.maven.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom";
+      sha256 = "0m4lallnlhyfj3z24ispxzwvsxzaznhw6zsmk4j74sibr5kqh7xm";
+    };
+    "nix-typesafe-ivy-releases/org.scala-sbt/compiler-interface/0.13.12/srcs/compiler-interface-sources.jar" = {
+      url = "https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/compiler-interface/0.13.12/srcs/compiler-interface-sources.jar";
+      sha256 = "0rjjdc283wdv861yy9x0ssn5bh7mm371sznvp5hsayynd7h0r0z7";
+    };
+  };
+}

--- a/tests/multi-build/three/project/build.properties
+++ b/tests/multi-build/three/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.12

--- a/tests/multi-build/three/project/plugins.sbt
+++ b/tests/multi-build/three/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.5")

--- a/tests/multi-build/three/three.nix
+++ b/tests/multi-build/three/three.nix
@@ -1,0 +1,10 @@
+{sbtix, two}:
+sbtix.buildSbtProgram {
+    name = "sbtix-multibuild-three";
+    src = ./.;
+    repo = [ (import ./manual-repo.nix)
+             (import ./repo.nix)
+             (import ./project/repo.nix)
+           ];
+    sbtixBuildInputs = [ two ];
+}

--- a/tests/multi-build/two/Two.scala
+++ b/tests/multi-build/two/Two.scala
@@ -1,0 +1,5 @@
+object Two {
+  def doStuff() {
+    println("Hello from two")
+  }
+}

--- a/tests/multi-build/two/build.sbt
+++ b/tests/multi-build/two/build.sbt
@@ -1,0 +1,13 @@
+val org = "sbtix-test-multibuild"
+
+val ver = "0.1.0-SNAPSHOT"
+
+organization := org
+
+name := "mb-two"
+
+version := ver
+
+libraryDependencies += org %% "mb-one" % ver extra ("nix" -> "")
+
+projectID := projectID.value.extra("nix" -> "")

--- a/tests/multi-build/two/manual-repo.nix
+++ b/tests/multi-build/two/manual-repo.nix
@@ -1,0 +1,42 @@
+# this file must still be generated manually.  
+{
+  "repos" = {
+    "nix-public" = "";
+    "nix-typesafe-ivy-releases" = "[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]";
+  };
+  "artifacts" = {
+    # dependencies so sbt can build the sbt-compiler-interface (http://www.scala-sbt.org/0.13/docs/Compiler-Interface.html)
+    "nix-public/org/scala-lang/jline/2.10.6/jline-2.10.6.pom" = {
+      url = "https://repo1.maven.org/maven2/org/scala-lang/jline/2.10.6/jline-2.10.6.pom";
+      sha256 = "16mg4b2c1m6gcq901wy6f6jpy8spw2yh909gi826xykq89ja94dg";
+    };
+    "nix-public/org/scala-lang/jline/2.10.6/jline-2.10.6.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scala-lang/jline/2.10.6/jline-2.10.6.jar";
+      sha256 = "1cfk6whncx2g87grwdfmz6f76bn807saqik91iwcfv099b1jngw1";
+    };
+    "nix-public/jline/jline/2.12.1/jline-2.12.1.pom" = {
+      url = "https://repo1.maven.org/maven2/jline/jline/2.12.1/jline-2.12.1.pom";
+      sha256 = "0pzjaccy3svy4arrzs02c2yif7plbwlr39kvs38qr68ij0v20m0j";
+    };
+    "nix-public/jline/jline/2.12.1/jline-2.12.1.jar" = {
+      url = "https://repo1.maven.org/maven2/jline/jline/2.12.1/jline-2.12.1.jar";
+      sha256 = "03wl5r6xd58n5504rspqx086kjaw55faxa5fz2kghipg5k7is7y3";
+    };
+    "nix-public/org/fusesource/jansi/jansi/1.4/jansi-1.4.pom" = {
+      url = "https://repo1.maven.org/maven2/org/fusesource/jansi/jansi/1.4/jansi-1.4.pom";
+      sha256 = "0rgprkbg4ljarf0x79snk2h1b0974glhl2fw1bxkxbw8k3ifda1s";
+    };
+    "nix-public/org/fusesource/jansi/jansi/1.4/jansi-1.4.jar" = {
+      url = "https://repo1.maven.org/maven2/org/fusesource/jansi/jansi/1.4/jansi-1.4.jar";
+      sha256 = "183ms545msn02fl0181rwbcifc8qy82rz4l6dglnhv9la8a1bnc2";
+    };
+    "nix-public/org/sonatype/oss/oss-parent/7/oss-parent-7.pom" = {
+      url = "https://repo1.maven.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom";
+      sha256 = "0m4lallnlhyfj3z24ispxzwvsxzaznhw6zsmk4j74sibr5kqh7xm";
+    };
+    "nix-typesafe-ivy-releases/org.scala-sbt/compiler-interface/0.13.12/srcs/compiler-interface-sources.jar" = {
+      url = "https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/compiler-interface/0.13.12/srcs/compiler-interface-sources.jar";
+      sha256 = "0rjjdc283wdv861yy9x0ssn5bh7mm371sznvp5hsayynd7h0r0z7";
+    };
+  };
+}

--- a/tests/multi-build/two/project/build.properties
+++ b/tests/multi-build/two/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.12

--- a/tests/multi-build/two/two.nix
+++ b/tests/multi-build/two/two.nix
@@ -1,0 +1,9 @@
+{sbtix, one}:
+sbtix.buildSbtLibrary {
+    name = "sbtix-multibuild-two";
+    src = ./.;
+    repo = [ (import ./manual-repo.nix)
+             (import ./repo.nix)
+           ];
+    sbtixBuildInputs = [ one ];
+}


### PR DESCRIPTION
This is mostly an implementation of #19, except for that I ended up using an extra() attribute instead of adding a new setting. This is still pretty hacky, but I don't want to require the Sbtix SBT plugin outside of `sbtix-gen-*`.

I also added `sbtix.buildSbtLibrary` which publishes the build to a local Ivy repository, and `sbtix.buildSbtProgram` which packages programs built using sbt-native-packager.