### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+repo.nix linguist-vendored=true
+manual-repo.nix linguist-vendored=true


### PR DESCRIPTION
Blacklists manual-repo.nix and repo.nix to avoid false-positives during
linguist indexes. GitHub uses linguist to show language statistics
in the repo overview, but all these generated .nix files cause cause
false-positives.

see https://github.com/github/linguist#vendored-code