### PR TITLE
WIP: Add sbt 1.1.x support

### DIFF
--- a/plugin/build.sbt
+++ b/plugin/build.sbt
@@ -4,9 +4,9 @@ name := "sbtix"
 organization := "se.nullable.sbtix"
 version := "0.2-SNAPSHOT"
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15-1")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")
 
-ScriptedPlugin.scriptedSettings
+ScriptedPlugin.projectSettings
 scriptedLaunchOpts ++= Seq(
   s"-Dplugin.version=${version.value}"
 )

--- a/plugin/project/build.properties
+++ b/plugin/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.1.0

--- a/plugin/project/plugins.sbt
+++ b/plugin/project/plugins.sbt
@@ -1,5 +1,5 @@
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15-1")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")
 
 resolvers += Resolver.typesafeIvyRepo("releases")

--- a/plugin/src/main/scala/se/nullable/sbtix/NixPlugin.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/NixPlugin.scala
@@ -18,7 +18,7 @@ object NixPlugin extends AutoPlugin {
         .filterNot(_.extraAttributes.contains("e:nix"))
         -- projectDependencies.value)
 
-      val depends = modules.flatMap(coursier.FromSbt.dependencies(_, scalaVersion.value, scalaBinaryVersion.value, "jar")).map(_._2)
+      val depends = modules.flatMap(coursier.FromSbt.dependencies(_, scalaVersion.value, scalaBinaryVersion.value)).map(_._2)
         .filterNot {
           _.module.organization == "se.nullable.sbtix"
         } //ignore the sbtix dependency that gets added because of the global sbtix plugin

--- a/plugin/src/main/scala/se/nullable/sbtix/NixResolver.scala
+++ b/plugin/src/main/scala/se/nullable/sbtix/NixResolver.scala
@@ -16,7 +16,6 @@ object NixResolver {
         NixResolver(ivy.name, root, Some(pattern))
       case mvn: MavenRepository => NixResolver(mvn.name, mvn.root, None)
       case cr: ChainedResolver => ???
-      case jn1: JavaNet1Repository => ???
       case raw: RawRepository => ???
     }
 


### PR DESCRIPTION
@teozkr thx for the guidance and since i am on that path i decided to push this forward later this week.
Current state of affairs #34 :
```
[info] Compiling 7 Scala sources to /home/username/projects/github/Sbtix/plugin/target/scala-2.12/sbt-1.0/classes ...
[error] /home/username/projects/github/Sbtix/plugin/src/main/scala/se/nullable/sbtix/CoursierArtifactFetcher.scala:22:41: type mismatch;
[error]  found   : coursier.Dependency
[error]     (which expands to)  coursier.core.Dependency
[error]  required: (coursier.Dependency, Map[String,String])
[error]     (which expands to)  (coursier.core.Dependency, Map[String,String])
[error]   private val moduleId = ToSbt.moduleId(dep)
[error]                                         ^
[error] /home/username/projects/github/Sbtix/plugin/src/main/scala/se/nullable/sbtix/NixResolver.scala:19:17: not found: type JavaNet1Repository
[error]       case jn1: JavaNet1Repository => ???
[error]                 ^
[error] /home/username/projects/github/Sbtix/plugin/src/main/scala/se/nullable/sbtix/NixPlugin.scala:21:116: too many arguments (4) for method dependencies: (module: sbt.ModuleID, scalaVersion: Strin
g, scalaBinaryVersion: String)Seq[(String, coursier.Dependency)]                                                                                                                                          
[error]       val depends = modules.flatMap(coursier.FromSbt.dependencies(_, scalaVersion.value, scalaBinaryVersion.value, "jar")).map(_._2)
[error]                                                                                                                    ^
[error] three errors found
[error] (Compile / compileIncremental) Compilation failed
```
to be continued