### PR TITLE
Pin `nixpkgs` and `sbt`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,17 @@
-{ pkgs ? import <nixpkgs> {} }:
+let
+  fetchNixpkgs = import ./fetchNixpkgs.nix;
+
+  nixpkgs = fetchNixpkgs {
+     rev          = "78d4a1e3ea294ef5f1dcba110825831c02f3a46c";
+     sha256       = "0sv1f6bwbisijp1h0g3qvv43m5hq74xlwsnv5wm27mbi8lzgm057";
+     outputSha256 = "1f4x4bkssclmcprd0lm52sjlnnyfmabgxff8cdf68y6dc1lkhz5z";
+  };
+
+  pinSBT = packagesNew: packagesOld: {
+    sbt = packagesNew.callPackage ./sbt.nix { };
+  };
+
+in
+
+{ pkgs ? import nixpkgs { overlays = [ pinSBT ]; } }:
 pkgs.callPackage ./sbtix-tool.nix {}

--- a/fetchNixpkgs.nix
+++ b/fetchNixpkgs.nix
@@ -1,0 +1,49 @@
+{ rev                             # The Git revision of nixpkgs to fetch
+, sha256                          # The SHA256 of the downloaded data
+, outputSha256 ? null             # The SHA256 fixed-output hash
+, system ? builtins.currentSystem # This is overridable if necessary
+}:
+
+if (0 <= builtins.compareVersions builtins.nixVersion "1.12")
+
+# In Nix 1.12, we can just give a `sha256` to `builtins.fetchTarball`.
+then (
+  builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    sha256 = outputSha256;
+  })
+
+# This hack should at least work for Nix 1.11
+else (
+  (rec {
+    tarball = import <nix/fetchurl.nix> {
+      url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+      inherit sha256;
+    };
+
+    builtin-paths = import <nix/config.nix>;
+
+    script = builtins.toFile "nixpkgs-unpacker" ''
+      "$coreutils/mkdir" "$out"
+      cd "$out"
+      "$gzip" --decompress < "$tarball" | "$tar" -x --strip-components=1
+    '';
+
+    nixpkgs = builtins.derivation ({
+      name = "nixpkgs-${builtins.substring 0 6 rev}";
+
+      builder = builtins.storePath builtin-paths.shell;
+
+      args = [ script ];
+
+      inherit tarball system;
+
+      tar       = builtins.storePath builtin-paths.tar;
+      gzip      = builtins.storePath builtin-paths.gzip;
+      coreutils = builtins.storePath builtin-paths.coreutils;
+    } // (if null == outputSha256 then { } else {
+      outputHashMode = "recursive";
+      outputHashAlgo = "sha256";
+      outputHash = outputSha256;
+    }));
+  }).nixpkgs)

--- a/sbt.nix
+++ b/sbt.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, jre }:
+
+stdenv.mkDerivation rec {
+  name = "sbt-${version}";
+  version = "0.13.13";
+
+  src = fetchurl {
+    url = "https://dl.bintray.com/sbt/native-packages/sbt/${version}/${name}.tgz";
+    sha256 = "0ygrz92qkzasj6fps1bjg7wlgl69867jjjc37yjadib0l8hkvl20";
+  };
+
+  patchPhase = ''
+    echo -java-home ${jre.home} >>conf/sbtopts
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/sbt $out/bin
+    cp -ra . $out/share/sbt
+    ln -s $out/share/sbt/bin/sbt $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.scala-sbt.org/;
+    license = licenses.bsd3;
+    description = "A build tool for Scala, Java and more";
+    maintainers = with maintainers; [ rickynils ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
I accidentally installed Sbtix using a recent version of `nixpkgs` where
`sbt` defaults to version 1.1.4 so this change pins `sbt` to `0.13.13` instead
and also pins `nixpkgs` to the latest stable release (18.03) to improve the
determinism of the installer

Note that pinning `nixpkgs` is optional and I can undo that change if you
prefer

Also, you don't even have to merge this change at all.  I'm fine keeping this
just as a branch that people can use as a workaround until #34 is complete